### PR TITLE
Return original text as tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Vietnamese Word Tokenizer
+
+This is a fork of the code from http://mim.hus.vnu.edu.vn/dsl/tools/tokenizer

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>vitk-tok</artifactId>
     <groupId>ai.vitk</groupId>
-    <version>5.2</version>
+    <version>5.2.1-bw</version>
     <contributors>
         <contributor>
             <name>Lê Hồng Phương</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,25 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/src/test/java/ai/vitk/tok/TokenizerTest.java
+++ b/src/test/java/ai/vitk/tok/TokenizerTest.java
@@ -32,6 +32,15 @@ public class TokenizerTest {
         );
     }
 
+    @Test
+    public void givenVietnameseThatWouldBeNormalised_whenTokenizing_thenOriginalTokensReturned() {
+        // kỹ would be normalised to kĩ internally
+        checkTokenization(
+                "Direct message để được chúng mình tư vấn kỹ hơn nhé",
+                "Direct","message", "để", "được", "chúng mình", "tư vấn", "kỹ", "hơn", "nhé"
+        );
+    }
+
     private void checkTokenization(String text, String... expectedTokens) {
         List<Token> tokens = tokenizer.tokenize(text);
         List<String> actual = tokens.stream()

--- a/src/test/java/ai/vitk/tok/TokenizerTest.java
+++ b/src/test/java/ai/vitk/tok/TokenizerTest.java
@@ -1,0 +1,43 @@
+package ai.vitk.tok;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ai.vitk.type.Token;
+
+public class TokenizerTest {
+
+    private Tokenizer tokenizer;
+
+    @Before
+    public void setup() {
+        tokenizer = new Tokenizer();
+    }
+
+    @Test
+    public void givenVietnamese_whenTokenizing_thenTokensReturned() {
+        checkTokenization(
+                "Hà Nội mùa này vắng những cơn mưa",
+                "Hà Nội", "mùa", "này", "vắng", "những", "cơn", "mưa"
+        );
+        checkTokenization(
+                "Việt Nam là quốc gia nằm ở phía Đông bán đảo Đông Dương thuộc khu vực Đông Nam Á",
+                "Việt Nam", "là", "quốc gia", "nằm", "ở", "phía", "Đông", "bán đảo", "Đông Dương", "thuộc", "khu vực", "Đông Nam", "Á"
+        );
+    }
+
+    private void checkTokenization(String text, String... expectedTokens) {
+        List<Token> tokens = tokenizer.tokenize(text);
+        List<String> actual = tokens.stream()
+                .map(Token::getWord)
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList(expectedTokens), actual);
+    }
+
+}


### PR DESCRIPTION
The tokenizer was doing some normalisation of tokens (to match words to dictionary correctly I think), but those normalised tokens were being returned.

This change makes it return the original tokens (which could always be normalised again if wanted), so maintain the text that was in the source.

Also adds minimal tests etc