### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: java
-


### PR DESCRIPTION
We want to stop using Travis ideally. Seeing as this repo looks old and the travis file doesn't do much, I figure we can just remove it for now?